### PR TITLE
Support replace key without trailing space

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function apply_changes(data, delete_tags, insert_tags, replace_tags) {
 				var ins_data = {};
 				if (replace_tags[key]) {
 					ins_data[idx] = replace_tags[key];
-					var insert = yaml.safeDump(ins_data).replace(idx+': ', m[1]).replace(/\n$/, '');
+					var insert = yaml.safeDump(ins_data).replace(idx+':', m[1]).replace(/\n$/, '');
 				} else if (delete_tags[key]) {
 					var insert = null;
 				}


### PR DESCRIPTION
This fix allows to replace a key that don't contains a space after the colon, for example:

``` yaml
foo:
  - bar
  - baz
```

Befire this fix, if there was no space after `foo:`, the replacement of temporary index with the original key would not happen, resulting in invalid output (thus failed assertion).

---

I would happily add tests for this, but I don't get how the software is currently tested. `edit` seems to be never called in `tests/run.js`!
